### PR TITLE
feat: Initial setup of GitHub Pages blog with Minimal Mistakes theme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,62 @@
-theme: jekyll-theme-time-machine
+# Site settings
+title: "Learning Journey"
+name: "Amit Shri"
+description: "Backend engineer sharing learning experiences"
+url: "https://iamitshri.github.io"
+repository: "iamitshri/iamitshri.github.io"
+
+# Theme configuration
+minimal_mistakes_skin: "dark"  # Primary dark theme
+locale: "en-US"
+
+# Author settings
+author:
+  name: "Amit Shri"
+  bio: "Backend Software Engineer | Java, Node.js, Python, Bash, CI/CD, Cloud"
+  location: "Your Location" # Please replace "Your Location" with your actual location
+  links:
+    - label: "GitHub"
+      icon: "fab fa-fw fa-github"
+      url: "https://github.com/iamitshri"
+
+# Collections for better organization
+collections:
+  posts:
+    output: true
+    permalink: /:categories/:title/
+
+# Pagination
+paginate: 5
+paginate_path: /page:num/
+
+# Archives
+category_archive:
+  type: liquid
+  path: /categories/
+tag_archive:
+  type: liquid
+  path: /tags/
+
+# Defaults for posts
+defaults:
+  - scope:
+      path: ""
+      type: posts
+    values:
+      layout: single
+      author_profile: true
+      read_time: true
+      comments: false # Disabled comments as per common preference, can be enabled if needed
+      share: true
+      related: true
+      show_date: true
+
+# Plugins
+remote_theme: "mmistakes/minimal-mistakes@4.24.0"
+plugins:
+  - jekyll-remote-theme
+  - jekyll-include-cache
+  - jekyll-paginate
+  - jekyll-sitemap
+  - jekyll-gist
+  - jekyll-feed

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,0 +1,9 @@
+main:
+  - title: "Posts"
+    url: /posts/
+  - title: "Categories"
+    url: /categories/
+  - title: "Tags"
+    url: /tags/
+  - title: "Archive"
+    url: /year-archive/

--- a/_pages/category-archive.md
+++ b/_pages/category-archive.md
@@ -1,0 +1,6 @@
+---
+title: "Posts by Category"
+layout: categories
+permalink: /categories/
+author_profile: true
+---

--- a/_pages/tag-archive.md
+++ b/_pages/tag-archive.md
@@ -1,0 +1,6 @@
+---
+title: "Posts by Tag"
+layout: tags
+permalink: /tags/
+author_profile: true
+---

--- a/_pages/year-archive.md
+++ b/_pages/year-archive.md
@@ -1,0 +1,6 @@
+---
+title: "Posts by Year"
+layout: posts
+permalink: /year-archive/
+author_profile: true
+---

--- a/_posts/2025-05-25-step-functions-data-flow-a-beginners-guide.md
+++ b/_posts/2025-05-25-step-functions-data-flow-a-beginners-guide.md
@@ -1,0 +1,214 @@
+---
+layout: single
+title: "Step Functions Data Flow: A Beginner's Guide"
+categories: [devops, aws]
+tags: [step-functions, data-flow, serverless]
+date: 2025-05-25
+excerpt: "A beginner-friendly guide to understanding data flow and state manipulation in AWS Step Functions."
+author_profile: true
+read_time: true
+comments: false
+share: true
+related: true
+show_date: true
+---
+
+# Step Functions Data Flow: A Beginner's Guide
+
+AWS Step Functions is a serverless orchestrator that allows you to build resilient workflows using various AWS services. Understanding how data flows and is transformed between states is fundamental to leveraging its power. This guide is designed for beginners to grasp these core concepts.
+
+## State Machine Fundamentals for Beginners
+
+At its heart, a Step Functions workflow is a **state machine**. You define a series of **states**, the sequence they execute in, and how data is passed between them.
+
+*   **States:** These are the building blocks of your workflow. Each state represents a single unit of work. This could be invoking a Lambda function, running an AWS Batch job, publishing to an SNS topic, or even waiting for a certain amount of time.
+*   **Transitions:** States are connected by transitions. After a state completes its work, the state machine transitions to the next state as defined in your workflow.
+*   **Execution:** An execution is a single run of your state machine. Each execution has its own isolated data.
+
+## The JSON Data Blob: Your Workflow's Lifeblood
+
+Data in Step Functions is represented as a JSON object. This JSON "blob" is passed from one state to the next.
+
+*   **Execution Input:** When you start a new execution, you can provide an initial JSON input. This becomes the first state's input.
+*   **State Input:** The JSON data a state receives when it starts.
+*   **State Output:** The JSON data a state produces upon completion. **By default, the output of one state becomes the input of the next state.**
+
+## Key Fields for Data Manipulation
+
+Step Functions provides powerful fields within your state definitions to control and shape this JSON data. Let's explore the most important ones: `InputPath`, `Parameters`, `ResultSelector`, `ResultPath`, and `OutputPath`.
+
+### 1. `InputPath`: Filtering a State's Input
+
+The `InputPath` field allows you to select a portion of the incoming JSON data to be the effective input for the current state. You use a [JSONPath](https://stedolan.github.io/jq/manual/#path%20expressions) expression to specify which part of the input to use.
+
+**How it works:**
+Imagine your state receives this JSON input:
+```json
+{
+  "comment": "This is the initial data for the execution",
+  "details": {
+    "productId": "12345",
+    "quantity": 10,
+    "orderId": "PO-67890"
+  },
+  "customerInfo": {
+    "name": "Jane Doe",
+    "email": "jane.doe@example.com"
+  }
+}
+```
+If you set `InputPath: "$.details"`, then the actual data processed by your state (e.g., passed to a Lambda function) will only be:
+```json
+{
+  "productId": "12345",
+  "quantity": 10,
+  "orderId": "PO-67890"
+}
+```
+*   If `InputPath` is omitted or `null`, the entire input JSON is used (`$`).
+
+### 2. `Parameters`: Constructing the Input for a Task
+
+The `Parameters` field allows you to create a custom JSON object to be passed as input to a state's resource (like a Lambda function or an ECS task). You can use JSONPath expressions to extract values from the state's input and combine them with static values.
+
+**How it works:**
+Keys ending with `.$` indicate that their value is a JSONPath expression to be applied to the state's input. Other keys will have static values.
+
+Using the same initial input:
+```json
+{
+  "comment": "Initial data",
+  "details": { "productId": "12345", "quantity": 10 },
+  "customerInfo": { "name": "Jane Doe", "email": "jane.doe@example.com" }
+}
+```
+And this `Parameters` definition:
+```json
+"Parameters": {
+  "product_id.$": "$.details.productId",
+  "customer_email.$": "$.customerInfo.email",
+  "processing_status": "PENDING",
+  "metadata": {
+    "execution_id.$": "$$.Execution.Id" 
+  }
+}
+```
+The input sent to the state's resource (e.g., Lambda) will be:
+```json
+{
+  "product_id": "12345",
+  "customer_email": "jane.doe@example.com",
+  "processing_status": "PENDING",
+  "metadata": {
+    "execution_id": "arn:aws:states:us-east-1:123456789012:execution:MyStateMachine:my-execution-name" 
+  }
+}
+```
+*Note: `$$` provides access to context objects, like execution metadata (`$$.Execution.Id`).*
+
+### 3. `ResultSelector`: Shaping a Task's Raw Output
+
+After a task (like a Lambda function) finishes, it produces an output (its "result"). The `ResultSelector` field allows you to manipulate this raw result *before* it's combined with the state's original input via `ResultPath`. You can create a new JSON object from the task's result using key-value pairs, where values can be static or selected from the task's result using JSONPath.
+
+**How it works:**
+Suppose your Lambda function returns this JSON:
+```json
+{
+  "statusCode": 200,
+  "body": {
+    "message": "Successfully processed",
+    "processedItems": 5,
+    "errors": []
+  },
+  "logStreamName": "2024/07/16/[$LATEST]abcdef123456"
+}
+```
+And you have this `ResultSelector`:
+```json
+"ResultSelector": {
+  "statusMessage.$": "$.body.message",
+  "itemCount.$": "$.body.processedItems",
+  "hasErrors": false 
+}
+```
+The output from `ResultSelector` (which then feeds into `ResultPath`) will be:
+```json
+{
+  "statusMessage": "Successfully processed",
+  "itemCount": 5,
+  "hasErrors": false
+}
+```
+
+### 4. `ResultPath`: Integrating Task Output with State Input
+
+The `ResultPath` field specifies where to place the (potentially `ResultSelector`-transformed) output of the task back into the *original state input*.
+
+**How it works:**
+Let the state's original input be `original_input_json`.
+Let the result from the task (after `ResultSelector`, if present) be `task_result_json`.
+
+*   **`ResultPath: null` (default):** The `task_result_json` *replaces* the `original_input_json` entirely. The state's output becomes just `task_result_json`.
+*   **`ResultPath: "$"`:** The `task_result_json` *replaces* the `original_input_json` entirely. Same as `null`.
+*   **`ResultPath: "$.someField"`:** The `task_result_json` is inserted into the `original_input_json` at the path specified by `someField`. For example, if `original_input_json` is `{"a": 1}` and `task_result_json` is `{"b": 2}`, and `ResultPath: "$.taskOutput"`, the effective input to `OutputPath` becomes `{"a": 1, "taskOutput": {"b": 2}}`.
+*   **If `ResultPath` points to an existing field, that field is overwritten.**
+*   **If `ResultPath` is `null`, the original state input is discarded, and only the task's result (after `ResultSelector`) is passed to `OutputPath`.**
+
+**Example:**
+Original State Input:
+```json
+{ "originalKey": "originalValue" }
+```
+Task Result (after `ResultSelector`):
+```json
+{ "taskStatus": "SUCCESS" }
+```
+1.  If `ResultPath: "$.taskDetails"`:
+    Output fed to `OutputPath`:
+    ```json
+    {
+      "originalKey": "originalValue",
+      "taskDetails": { "taskStatus": "SUCCESS" }
+    }
+    ```
+2.  If `ResultPath: null`:
+    Output fed to `OutputPath`:
+    ```json
+    { "taskStatus": "SUCCESS" }
+    ```
+
+### 5. `OutputPath`: Filtering the Final State Output
+
+Finally, `OutputPath` allows you to filter the JSON data that results from the `ResultPath` logic. This filtered JSON becomes the actual output of the state, passed on to the next state.
+
+**How it works:**
+It uses a JSONPath expression to select a portion of the JSON data produced after `ResultPath` has done its work.
+
+**Example:**
+After `ResultPath`, the intermediate JSON is:
+```json
+{
+  "originalKey": "originalValue",
+  "taskDetails": {
+    "status": "SUCCESS",
+    "data": { "value": 100 }
+  },
+  "executionId": "exec-abc-123"
+}
+```
+If `OutputPath: "$.taskDetails.data"`, the final output of the state will be:
+```json
+{ "value": 100 }
+```
+If `OutputPath` is omitted or `null`, the entire JSON object after `ResultPath` processing is passed as the state's output.
+
+## Order of Operations: A Summary
+
+1.  **`InputPath`**: Filters the state's input.
+2.  **`Parameters`**: Constructs the input for the state's task (e.g., Lambda).
+3.  *(Task Execution)*
+4.  **`ResultSelector`**: Shapes the raw result from the task.
+5.  **`ResultPath`**: Merges the (selected) task result back into the original state input.
+6.  **`OutputPath`**: Filters the final output of the state.
+
+Understanding these data manipulation fields is key to building flexible and powerful Step Functions workflows. Start with simple use cases and gradually incorporate these fields as your workflows become more complex. The AWS Step Functions console's execution visualization is an invaluable tool for seeing how data transforms at each step. Happy orchestrating!

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,0 +1,4 @@
+---
+---
+@import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}";
+@import "minimal-mistakes";

--- a/index.html
+++ b/index.html
@@ -1,1 +1,4 @@
-"Hello World" 
+---
+layout: home
+author_profile: true
+---


### PR DESCRIPTION
This commit includes the initial setup for your iamitshri.github.io blog:

- I configured the Minimal Mistakes Jekyll theme (dark skin).
- I created the necessary directory structure (_posts, _pages, _data, assets).
- I added _config.yml with site, author, and theme settings.
- I set up index.html as the homepage.
- I included main.scss for custom SASS/CSS overrides.
- I defined navigation links in _data/navigation.yml.
- I created archive pages for categories, tags, and years.
- I added a sample blog post demonstrating the structure and frontmatter for technical content.

The blog is configured for automatic organization by categories, tags, and dates, and aims to provide an optimal reading experience for technical content.